### PR TITLE
Expose build_spec() and compile_and_init() for scene composition

### DIFF
--- a/src/ada_assets/assembly.py
+++ b/src/ada_assets/assembly.py
@@ -92,7 +92,29 @@ def assemble_ada(
     if tool_tip not in TOOL_TIPS:
         raise ValueError(f"Unknown tool_tip '{tool_tip}'. Available: {sorted(TOOL_TIPS.keys())}")
 
-    spec = _build_spec(with_human=with_human, with_camera=with_camera, tool=tool, tool_tip=tool_tip, with_floor=with_floor)
+    spec = build_spec(with_human=with_human, with_camera=with_camera, tool=tool, tool_tip=tool_tip, with_floor=with_floor)
+    return compile_and_init(spec, tool=tool)
+
+
+def compile_and_init(
+    spec: mujoco.MjSpec,
+    *,
+    tool: str | None = None,
+) -> tuple[mujoco.MjModel, mujoco.MjData]:
+    """Compile a spec, apply stow keyframe, and initialize the tool freejoint.
+
+    Scenes that extend the base ADA spec (e.g. by adding a table or plate)
+    should call this instead of compiling directly so the post-build init
+    (keyframe + tool pose) stays consistent.
+
+    Args:
+        spec: A spec returned by ``build_spec`` (possibly with extra bodies added).
+        tool: Tool name passed to ``build_spec`` — ``"articutool"``, ``"forque"``,
+              or ``None``. Used to initialize the tool freejoint to its grasp site.
+
+    Returns:
+        Compiled MuJoCo model and data, with the JACO2 at stow keyframe.
+    """
     model = spec.compile()
     data = mujoco.MjData(model)
 
@@ -176,7 +198,7 @@ def _attach_tool(spec: mujoco.MjSpec, tool: str, tool_tip: str = "fork") -> None
             ex.bodyname2 = tb
 
 
-def _build_spec(
+def build_spec(
     *,
     with_human: bool = True,
     with_camera: bool = True,
@@ -261,7 +283,7 @@ def main() -> int:
     print(f"ADA assembled: nbody={model.nbody} ngeom={model.ngeom} njnt={model.njnt} nu={model.nu}")
 
     if args.save:
-        spec = _build_spec(
+        spec = build_spec(
             with_human=not args.no_human,
             with_camera=not args.no_camera,
             tool=tool,


### PR DESCRIPTION
## Summary

Refactors `assemble_ada()` into two reusable public helpers so other packages can build the ADA spec, mutate it (add furniture/objects), and compile through the same shared init path.

- `build_spec(...)` — produce the bare-robot `MjSpec` (uncompiled). Previously the private `_build_spec`.
- `compile_and_init(spec, *, tool=None)` — compile any spec, apply the `stow` keyframe, and snap the tool freejoint to its grasp site on `link_6`.
- `assemble_ada(...)` — unchanged signature and behavior; now just chains the two.

## Why

The upcoming ADA feeding demo (`ada_mj`) needs to extend the bare ADA scene with a table, plate, and food items. Today that would mean either forking `assemble_ada` or post-processing the compiled `MjModel`. With `build_spec` + `compile_and_init` public, scene composition becomes:

```python
spec = build_spec(tool="articutool", ...)   # bare ADA spec
_add_table_and_plate(spec)                  # mutate
_add_food_items(spec, ...)                  # mutate
model, data = compile_and_init(spec, tool="articutool")
```

Same pattern will work for any future demo scene (bedside, etc.).

## Test plan

- [x] `assemble_ada()` callers unchanged — same return value, same keyframe + tool init.
- [x] `uv run python -m ada_assets.assembly` (CLI) still works.
- [x] Smoke-tested via `ada_mj.scenes.assemble_table_demo()`, which uses the new helpers to assemble the full feeding scene (nbody=36, ngeom=82, stow keyframe applied, tool snapped to grasp).