### PR TITLE
camera: fix backwards MuJoCo cameras (OpenCV optical frame → OpenGL convention)

### DIFF
--- a/src/ada_assets/models/camera.xml
+++ b/src/ada_assets/models/camera.xml
@@ -130,7 +130,10 @@
 
             <!-- color_optical_frame: camera_link rotated by rpy=[-π/2, 0, -π/2].
                  z points into the scene, x right, y down (OpenCV convention).
-                 This is the frame MuJoCo cameras should use for rendering. -->
+                 This is the calibrated hardware extrinsic frame. NOTE: MuJoCo
+                 cameras do NOT use this orientation directly — they view down
+                 local -z with +y up (OpenGL), the OpenCV frame rotated 180°
+                 about x. The <camera> elements below bake in that flip. -->
             <site name="color_optical_frame" pos="0.0194 -0.01606 0.029014"
                   quat="0.706951 -0.003895 -0.002741 0.707246"
                   size="0.003" rgba="0 1 1 0.5"/>
@@ -156,14 +159,18 @@
                  Depth post-processing (ada_mj):
                    - Clip to [0.16, 10.0] m to match D415 operating range
                    - Apply intrinsic matrix for pixel-accurate projection -->
+            <!-- quat = color_optical_frame quat ∘ Rx(180°): converts the
+                 OpenCV optical frame (+z forward, +y down) to MuJoCo's camera
+                 convention (-z forward, +y up) so the camera looks along the
+                 real optical axis instead of backwards. See ada_assets#6. -->
             <camera name="d415_color" pos="0.0194 -0.01606 0.029014"
-                    quat="0.706951 -0.003895 -0.002741 0.707246"
+                    quat="0.003895 0.706951 0.707246 0.002741"
                     fovy="43" resolution="1280 720"/>
             <!-- Depth uses aligned_depth_to_color (same frame and FOV as color).
                  Render with renderer.enable_depth_rendering(True).
                  Clip output to [0.16, 10.0] m for D415 fidelity. -->
             <camera name="d415_depth" pos="0.0194 -0.01606 0.029014"
-                    quat="0.706951 -0.003895 -0.002741 0.707246"
+                    quat="0.003895 0.706951 0.707246 0.002741"
                     fovy="43" resolution="1280 720"/>
           </body>
         </body>

--- a/tests/test_camera_convention.py
+++ b/tests/test_camera_convention.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Lock the wrist-camera frame convention (ada_assets#6).
+
+MuJoCo cameras view down local -z with +y up (OpenGL); the D415
+``color_optical_frame`` is the OpenCV convention (+z forward, +y down). The
+``<camera>`` elements must bake in the 180°-about-x flip between the two, or the
+cameras point backwards (and render upside-down) relative to the real optics.
+
+These tests compile the assembled ADA model and assert the rendered cameras look
+along the real optical axis — a regression here means the convention flip in
+``models/camera.xml`` was lost.
+"""
+
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+import pytest
+
+from ada_assets.assembly import build_spec, compile_and_init
+
+OPTICAL_SITE = "camera/color_optical_frame"
+CAMERAS = ("camera/d415_color", "camera/d415_depth")
+
+
+@pytest.fixture(scope="module")
+def model_data():
+    spec = build_spec(with_human=False, with_camera=True, tool="articutool")
+    return compile_and_init(spec, tool="articutool")
+
+
+def _rot(mat9: np.ndarray) -> np.ndarray:
+    return np.asarray(mat9).reshape(3, 3)
+
+
+@pytest.mark.parametrize("camera", CAMERAS)
+def test_camera_looks_along_optical_axis(model_data, camera):
+    """MuJoCo view axis (-z) aligns with the optical frame forward (+z)."""
+    model, data = model_data
+    cam = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, camera)
+    opt = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, OPTICAL_SITE)
+    assert cam >= 0 and opt >= 0
+
+    view_dir = -_rot(data.cam_xmat[cam])[:, 2]  # MuJoCo camera looks along -z
+    opt_fwd = _rot(data.site_xmat[opt])[:, 2]  # OpenCV optical frame: +z forward
+
+    # +1 = looking along the real optical axis; -1 = backwards (the bug).
+    assert float(view_dir @ opt_fwd) > 0.999
+
+
+@pytest.mark.parametrize("camera", CAMERAS)
+def test_camera_image_is_upright(model_data, camera):
+    """Image-up (+y_cam) opposes optical-down (+y_opt) — not rolled or flipped.
+
+    Together with the view-axis test this pins the full OpenCV->OpenGL flip
+    (Rx 180°): -z_cam = +z_opt, +y_cam = -y_opt, +x_cam = +x_opt.
+    """
+    model, data = model_data
+    cam = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, camera)
+    opt = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, OPTICAL_SITE)
+
+    cam_up = _rot(data.cam_xmat[cam])[:, 1]  # MuJoCo camera +y is up
+    opt_down = _rot(data.site_xmat[opt])[:, 1]  # OpenCV optical frame +y is down
+
+    assert float(cam_up @ opt_down) < -0.999


### PR DESCRIPTION
## Why
The MuJoCo wrist cameras (`d415_color`, `d415_depth`) pointed **backwards** — viewing axis exactly opposite the real D415 optical axis — because the `<camera>` elements inherited the `color_optical_frame` quaternion verbatim. That site is OpenCV (+z forward, +y down); MuJoCo cameras view down −z with +y up (OpenGL). The two differ by Rx(180°).

`CameraTSR` reads the live `cam_xmat` and aligns the MuJoCo −z axis at the plate, so it stayed *internally consistent* (sim render showed the plate, framing unit tests passed) — masking that the **physical lens aimed 180° away from the plate**. Wrong on hardware; rendered image upside-down vs. the real camera.

## What
- Rotate both `<camera>` quats by Rx(180°): `0.706951 -0.003895 -0.002741 0.707246` → `0.003895 0.706951 0.707246 0.002741`.
- Leave the `color_optical_frame` **site** unchanged (calibrated hardware extrinsics).
- No `observe`/`CameraTSR` change — it auto-adapts from `cam_xmat`.
- New `tests/test_camera_convention.py` compiles the assembled ADA model and locks the convention (`dot(−z_cam, +z_opt) ≈ +1` and image-up = optical-down).

Fixes #6.

## Evidence (before → after, assembled model)
```
dot(MuJoCo view −z, optical +z):   −1.0   →   +1.0
dot(view, camera→plate) @ home:    −0.975 →   +0.975
```
End-to-end: `observe_plate` in sim renders the plate **dead-centered at pixel (640, 360)** of 1280×720, upright, food + fork in frame.

## Test plan
- `uv run pytest` (ada_assets): 4 passed; ruff clean.
- `ada_mj` `test_camera_tsr.py` + `test_feeding_session.py` (incl. slow observe/sim acceptance): 32 passed — no regression; `observe` still frames and clears the plate.
- Manual render verification at the observe pose (image centered + upright).
